### PR TITLE
Boot splash fixes

### DIFF
--- a/boot-splash.conf
+++ b/boot-splash.conf
@@ -1,0 +1,38 @@
+# Copyright 2012 The ChromiumOS Authors
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+description    "Displays an animation while the system is booting"
+author         "chromium-os-dev@chromium.org"
+
+# UI should still be able to come up even if we fail.
+oom score -100
+export fork
+
+# boot-splash depends on udev-trigger-early because frecon does need
+# graphics device to be ready to display splash screen and tty (ptmx)
+# device to create terminals, it also uses input devices (though they
+# can also be hotplugged).
+
+start on stopped udev-trigger-early
+
+# If no assets are available to show, assume "embedded".
+# If a specific embedded device needs different parameters, see:
+#   http://upstart.ubuntu.com/cookbook/#separating-variables-from-the-job
+env ASSETLESS_ARGS="--enable-osc --enable-vts --pre-create-vts"
+
+# Script stanzas can only execute one program,
+# and that program needs to be frecon.
+pre-start script
+  # Set the backlight to 40% of its maximum level.
+  BACKLIGHT_DIR=/sys/class/backlight
+  if [ -d ${BACKLIGHT_DIR} ] &&
+     [ -n "$(find ${BACKLIGHT_DIR} -maxdepth 0 ! -empty)" ]; then
+    backlight_tool --set_brightness_percent=40.0 || true
+  fi
+end script
+
+script
+  # Everything has been ripped out here and moved to chromeos_startup.sh and chromeos_startup_v118.sh for pre and post-v116 cros respectively
+  exit 0
+end script

--- a/chromeos_startup.sh
+++ b/chromeos_startup.sh
@@ -130,5 +130,6 @@ else
         ((i++))
     done
     echo "Boot splash finished. Handing over to real startup."
+    rm -f /bootsplash-complete
     exec /sbin/chromeos_startup.sh.old
 fi

--- a/chromeos_startup.sh
+++ b/chromeos_startup.sh
@@ -39,7 +39,9 @@ echo "Oh fuck - ChromeOS is trying to kill itself." >/usr/share/chromeos-assets/
 echo "ChromeOS detected developer mode and is trying to disable it to" >>/usr/share/chromeos-assets/text/boot_messages/en/block_devmode_virtual.txt
 echo "comply with FWMP. This is most likely a bug and should be reported to" >>/usr/share/chromeos-assets/text/boot_messages/en/block_devmode_virtual.txt
 echo "the murkmod GitHub issues page." >>/usr/share/chromeos-assets/text/boot_messages/en/block_devmode_virtual.txt
+
 echo "i sure hope you did that on purpose (powerwashing system)" >/usr/share/chromeos-assets/text/boot_messages/en/power_wash.txt
+
 echo "oops UwU i did a little fucky wucky and your system is trying to repair" >/usr/share/chromeos-assets/text/boot_messages/en/self_repair.txt
 echo "itself~ sorry OwO" >>/usr/share/chromeos-assets/text/boot_messages/en/self_repair.txt
 
@@ -115,6 +117,18 @@ else
         fi
     done
 
-    echo "Plugins run. Handing over to real startup..."
+    echo "Plugins run. Waiting for boot splash to finish..."
+    i=0
+    while ! test -f "/bootsplash-complete"; do
+        sleep 0.1
+        if [ ! -f /disable-bootsplash-failsafe ]; then # allow disabling failsafe if, say, i don't know, you wanted to set the entire bee movie as your boot splash
+            if [[ "$i" -gt 600 ]]; then # 1 minute failsafe
+                echo "Boot splash reached 1 minute failsafe. Exiting..."
+                break
+            fi
+        fi
+        ((i++))
+    done
+    echo "Boot splash finished. Handing over to real startup."
     exec /sbin/chromeos_startup.sh.old
 fi

--- a/chromeos_startup_v118.sh
+++ b/chromeos_startup_v118.sh
@@ -39,7 +39,9 @@ echo "Oh fuck - ChromeOS is trying to kill itself." >/usr/share/chromeos-assets/
 echo "ChromeOS detected developer mode and is trying to disable it to" >>/usr/share/chromeos-assets/text/boot_messages/en/block_devmode_virtual.txt
 echo "comply with FWMP. This is most likely a bug and should be reported to" >>/usr/share/chromeos-assets/text/boot_messages/en/block_devmode_virtual.txt
 echo "the murkmod GitHub issues page." >>/usr/share/chromeos-assets/text/boot_messages/en/block_devmode_virtual.txt
+
 echo "i sure hope you did that on purpose (powerwashing system)" >/usr/share/chromeos-assets/text/boot_messages/en/power_wash.txt
+
 echo "oops UwU i did a little fucky wucky and your system is trying to repair" >/usr/share/chromeos-assets/text/boot_messages/en/self_repair.txt
 echo "itself~ sorry OwO" >>/usr/share/chromeos-assets/text/boot_messages/en/self_repair.txt
 
@@ -121,6 +123,18 @@ else
         fi
     done
 
-    echo "Plugins run. Handing over to real startup..."
+    echo "Plugins run. Waiting for boot splash to finish..."
+    i=0
+    while ! test -f "/bootsplash-complete"; do
+        sleep 0.1
+        if [ ! -f /disable-bootsplash-failsafe ]; then # allow disabling failsafe if, say, i don't know, you wanted to set the entire bee movie as your boot splash
+            if [[ "$i" -gt 600 ]]; then # 1 minute failsafe
+                echo "Boot splash reached 1 minute failsafe. Exiting..."
+                break
+            fi
+        fi
+        ((i++))
+    done
+    echo "Boot splash finished. Handing over to real startup."
     exec /sbin/chromeos_startup.old
 fi

--- a/chromeos_startup_v118.sh
+++ b/chromeos_startup_v118.sh
@@ -136,5 +136,6 @@ else
         ((i++))
     done
     echo "Boot splash finished. Handing over to real startup."
+    rm -f /bootsplash-complete
     exec /sbin/chromeos_startup.old
 fi

--- a/fakemurk-daemon.sh
+++ b/fakemurk-daemon.sh
@@ -194,7 +194,7 @@ EOF
 } &
 
 {
-    echo "Witing for boot on daemon plugins (also just in case)"
+    echo "Waiting for boot on daemon plugins (also just in case)"
     sleep 60
     echo "Finding daemon plugins..."
     for file in /mnt/stateful_partition/murkmod/plugins/*.sh; do
@@ -203,4 +203,13 @@ EOF
             run_plugin $file
         fi
     done
+} &
+
+{
+    echo "Running bootsplash..."
+    BACKGROUND=0xfffefefe
+    ARGS="--frame-interval 25"
+    BOOT_IMAGES=/usr/share/chromeos-assets/images_100_percent/boot_splash_frame*.png
+    /sbin/frecon --clear "${BACKGROUND}" ${ARGS} ${BOOT_IMAGES}
+    touch 
 } &

--- a/fakemurk-daemon.sh
+++ b/fakemurk-daemon.sh
@@ -211,5 +211,6 @@ EOF
     ARGS="--frame-interval 25"
     BOOT_IMAGES=/usr/share/chromeos-assets/images_100_percent/boot_splash_frame*.png
     /sbin/frecon --clear "${BACKGROUND}" ${ARGS} ${BOOT_IMAGES}
-    touch 
+    touch /bootsplash-complete
+    echo "Bootsplash complete."
 } &

--- a/image_patcher.sh
+++ b/image_patcher.sh
@@ -122,6 +122,7 @@ patch_root() {
     echo "Installing startup services..."
     install "pre-startup.conf" $ROOT/etc/init/pre-startup.conf
     install "cr50-update.conf" $ROOT/etc/init/cr50-update.conf
+    install "boot-splash.conf" $ROOT/etc/init/boot-splash.conf
     echo "Installing other utilities..."
     install "ssd_util.sh" $ROOT/usr/share/vboot/bin/ssd_util.sh
     install "image_patcher.sh" $ROOT/sbin/image_patcher.sh

--- a/murkmod.sh
+++ b/murkmod.sh
@@ -87,8 +87,10 @@ install_patched_files() {
     install "mush.sh" /usr/bin/crosh
     install "pre-startup.conf" /etc/init/pre-startup.conf
     install "cr50-update.conf" /etc/init/cr50-update.conf
+    install "boot-splash.conf" /etc/init/boot-splash.conf
     install "ssd_util.sh" /usr/share/vboot/bin/ssd_util.sh
     install "image_patcher.sh" /sbin/image_patcher.sh
+    install "crossystem_boot_populator.sh" /sbin/crossystem_boot_populator.sh
     chmod 777 /sbin/fakemurk-daemon.sh /sbin/chromeos_startup.sh /sbin/chromeos_startup /usr/bin/crosh /usr/share/vboot/bin/ssd_util.sh /sbin/image_patcher.sh
 }
 

--- a/mush.sh
+++ b/mush.sh
@@ -165,11 +165,21 @@ EOF
         23) runjob attempt_chromebrew_install ;;
         24) runjob attempt_dev_install ;;
         25) runjob do_updates && exit 0 ;;
+        26) runjob do_dev_updates && exit 0 ;;
 
 
         *) echo && echo "Invalid option, dipshit." && echo ;;
         esac
     done
+}
+
+do_dev_updates() {
+    echo "Welcome to the secret murkmod developer update menu!"
+    echo "This utility allows you to install murkmod from a specific branch on the git repo."
+    echo "If you were trying to update murkmod normally, then don't panic! Just enter 'main' at the prompt and everything will work normally."
+    read -p "> (branch name, eg. main): " branch
+    doas "MURKMOD_BRANCH=$branch bash <(curl -SLk https://raw.githubusercontent.com/rainestorme/murkmod/main/murkmod.sh)"
+    exit
 }
 
 disable_ext() {


### PR DESCRIPTION
Allows for the playing of longer boot splashes by holding up the boot process until the splash finishes