### PR TITLE
Make the multi-line boot messages a little more readable when viewing the code.

### DIFF
--- a/chromeos_startup.sh
+++ b/chromeos_startup.sh
@@ -36,7 +36,9 @@ fi
 
 # note that this will lead to confusing behaviour, since it will appear as if it crashed as a result of fakemurk
 
-# startup plugins are also launched here, for low-level control over 
+# startup plugins are also launched here, for low-level control over the system
+# /path/to/example_plugin.sh
+
 
 # funny boot messages
 # multi-liners


### PR DESCRIPTION
This PR edits `chromeos_startup.sh` to make the multi-lined boot messages use`cat <<EOF` instead of `echo`. 
The output to the boot message's `txt` file is still the same, but just adds a little more readability to the source code.

(This PR also finishes an unfinished comment)