### PR TITLE
Fixes syntax error on developer mode installer when trying to fetch from Chromium Dash

### DIFF
--- a/murkmod-devmode.sh
+++ b/murkmod-devmode.sh
@@ -137,7 +137,7 @@ murkmod() {
     #local release_board="hatch"
     local board=${release_board%%-*}
     if [ $VERSION == "latest" ]; then
-        local builds=$(curl https://chromiumdash.appspot.com/cros/fetch_serving_builds?deviceCategory=Chrome%20OS)
+        local builds=$(curl -ks https://chromiumdash.appspot.com/cros/fetch_serving_builds?deviceCategory=Chrome%20OS)
         local hwid=$(jq "(.builds.$board[] | keys)[0]" <<<"$builds")
         local hwid=${hwid:1:-1}
         local milestones=$(jq ".builds.$board[].$hwid.pushRecoveries | keys | .[]" <<<"$builds")
@@ -167,7 +167,7 @@ murkmod() {
     done
     if [ $MATCH_FOUND -eq 0 ]; then
         echo "No match found on chrome100. Falling back to Chromium Dash."
-        local builds=$(curl https://chromiumdash.appspot.com/cros/fetch_serving_builds?deviceCategory=Chrome%20OS)
+        local builds=$(curl -ks https://chromiumdash.appspot.com/cros/fetch_serving_builds?deviceCategory=Chrome%20OS)
         local hwid=$(jq "(.builds.$board[] | keys)[0]" <<<"$builds")
         local hwid=${hwid:1:-1}
 

--- a/murkmod-devmode.sh
+++ b/murkmod-devmode.sh
@@ -137,7 +137,7 @@ murkmod() {
     #local release_board="hatch"
     local board=${release_board%%-*}
     if [ $VERSION == "latest" ]; then
-        local builds=$(curl -ks "https://chromiumdash.appspot.com/cros/fetch_serving_builds?deviceCategory=Chrome%20OS\\")
+        local builds=$(curl https://chromiumdash.appspot.com/cros/fetch_serving_builds?deviceCategory=Chrome%20OS)
         local hwid=$(jq "(.builds.$board[] | keys)[0]" <<<"$builds")
         local hwid=${hwid:1:-1}
         local milestones=$(jq ".builds.$board[].$hwid.pushRecoveries | keys | .[]" <<<"$builds")
@@ -167,7 +167,7 @@ murkmod() {
     done
     if [ $MATCH_FOUND -eq 0 ]; then
         echo "No match found on chrome100. Falling back to Chromium Dash."
-        local builds=$(curl -ks "https://chromiumdash.appspot.com/cros/fetch_serving_builds?deviceCategory=Chrome%20OS\\")
+        local builds=$(curl https://chromiumdash.appspot.com/cros/fetch_serving_builds?deviceCategory=Chrome%20OS)
         local hwid=$(jq "(.builds.$board[] | keys)[0]" <<<"$builds")
         local hwid=${hwid:1:-1}
 


### PR DESCRIPTION
I got an error when retrieving image download URL from Chromium Dash, so I modified the part that fetches builds.
![image](https://github.com/user-attachments/assets/80b9df18-f4e0-4071-93c5-2f5fb2d5bc33)
