### PR TITLE
Fixes get_largest_cros_blockdev and others on mush

### DIFF
--- a/mush.sh
+++ b/mush.sh
@@ -67,7 +67,7 @@ swallow_stdin() {
 }
 
 edit() {
-    if which nano 2>/dev/null; then
+    if doas which nano 2>/dev/null; then
         doas nano "$@"
     else
         doas vi "$@"

--- a/mush.sh
+++ b/mush.sh
@@ -9,7 +9,7 @@ get_largest_cros_blockdev() {
         tmp_size=$(cat "$blockdev"/size)
         remo=$(cat "$blockdev"/removable)
         if [ "$tmp_size" -gt "$size" ] && [ "${remo:-0}" -eq 0 ]; then
-            case "$(sfdisk -l -o name "/dev/$dev_name" 2>/dev/null)" in
+            case "$(doas sfdisk -l -o name "/dev/$dev_name" 2>/dev/null)" in
                 *STATE*KERN-A*ROOT-A*KERN-B*ROOT-B*)
                     largest="/dev/$dev_name"
                     size="$tmp_size"
@@ -17,11 +17,7 @@ get_largest_cros_blockdev() {
             esac
         fi
     done
-    if [ -n "$largest" ]; then
-        echo "$largest"
-    else
-        echo "/dev/mmcblk1"
-    fi
+    echo "$largest"
 }
 
 traps() {

--- a/mush.sh
+++ b/mush.sh
@@ -667,7 +667,7 @@ revert() {
     
     echo "Setting kernel priority"
 
-    DST=$(get_largest_nvme_namespace)
+    DST=$(get_largest_cros_blockdev)
 
     if doas "((\$(cgpt show -n \"$DST\" -i 2 -P) > \$(cgpt show -n \"$DST\" -i 4 -P)))"; then
         doas cgpt add "$DST" -i 2 -P 0
@@ -824,7 +824,7 @@ attempt_chromeos_update(){
 
         echo "Dumping emergency revert backup to stateful (this might take a while)..."
         echo "Finding correct partitions..."
-        local dst=$(get_largest_nvme_namespace)
+        local dst=$(get_largest_cros_blockdev)
         local tgt_kern=$(opposite_num $(get_booted_kernnum))
         local tgt_root=$(( $tgt_kern + 1 ))
 
@@ -914,7 +914,7 @@ attempt_backup_update(){
     read -r
 
     echo "Finding correct partitions..."
-    local dst=$(get_largest_nvme_namespace)
+    local dst=$(get_largest_cros_blockdev)
     local tgt_kern=$(opposite_num $(get_booted_kernnum))
     local tgt_root=$(( $tgt_kern + 1 ))
 
@@ -970,7 +970,7 @@ attempt_backup_update(){
 
 attempt_restore_backup_backup() {
     echo "Looking for backup files..."
-    dst=$(get_largest_nvme_namespace)
+    dst=$(get_largest_cros_blockdev)
     tgt_kern=$(opposite_num $(get_booted_kernnum))
     tgt_root=$(( $tgt_kern + 1 ))
 

--- a/mush.sh
+++ b/mush.sh
@@ -1,19 +1,27 @@
 #!/bin/bash
 
-get_largest_nvme_namespace() {
-    # this function doesn't exist if the version is old enough, so we redefine it
-    local largest size tmp_size dev
+get_largest_cros_blockdev() {
+    local largest size dev_name tmp_size remo
     size=0
-    dev=$(basename "$1")
-
-    for nvme in /sys/block/"${dev%n*}"*; do
-        tmp_size=$(cat "${nvme}"/size)
-        if [ "${tmp_size}" -gt "${size}" ]; then
-            largest="${nvme##*/}"
-            size="${tmp_size}"
+    for blockdev in /sys/block/*; do
+        dev_name="${blockdev##*/}"
+        echo "$dev_name" | grep -q '^\(loop\|ram\)' && continue
+        tmp_size=$(cat "$blockdev"/size)
+        remo=$(cat "$blockdev"/removable)
+        if [ "$tmp_size" -gt "$size" ] && [ "${remo:-0}" -eq 0 ]; then
+            case "$(sfdisk -l -o name "/dev/$dev_name" 2>/dev/null)" in
+                *STATE*KERN-A*ROOT-A*KERN-B*ROOT-B*)
+                    largest="/dev/$dev_name"
+                    size="$tmp_size"
+                    ;;
+            esac
         fi
     done
-    echo "${largest}"
+    if [ -n "$largest" ]; then
+        echo "$largest"
+    else
+        echo "/dev/mmcblk1"
+    fi
 }
 
 traps() {


### PR DESCRIPTION
Reverted to get_largest_nvme_namespace because the new one doesn't return anything on mush environment (on my chromebook's).