### PR TITLE
just a sign flip

### DIFF
--- a/daemon.sh
+++ b/daemon.sh
@@ -88,7 +88,7 @@ opposite_num() {
         launch_racer(){
             echo launching racer at "$(date)"
             {
-                if [ $(lsbval CHROMEOS_RELEASE_CHROME_MILESTONE) -ge "120" ] && which device_management_client >/dev/null 2>&1; then
+                if [ $(lsbval CHROMEOS_RELEASE_CHROME_MILESTONE) -le "120" ] && which device_management_client >/dev/null 2>&1; then
                     while true; do
                         device_management_client --action=remove_firmware_management_parameters >/dev/null 2>&1
                     done


### PR DESCRIPTION
the sign flip makes it so if the cros version is above 120 it will use cryptohome, and if below, it will use device_management_client