### PR TITLE
Remove the version check

### DIFF
--- a/daemon.sh
+++ b/daemon.sh
@@ -88,7 +88,7 @@ opposite_num() {
         launch_racer(){
             echo launching racer at "$(date)"
             {
-                if [ $(lsbval CHROMEOS_RELEASE_CHROME_MILESTONE) -ge "120" ] && which device_management_client >/dev/null 2>&1; then
+                if which device_management_client >/dev/null 2>&1; then
                     while true; do
                         device_management_client --action=remove_firmware_management_parameters >/dev/null 2>&1
                     done

--- a/daemon.sh
+++ b/daemon.sh
@@ -88,7 +88,7 @@ opposite_num() {
         launch_racer(){
             echo launching racer at "$(date)"
             {
-                if [ $(lsbval CHROMEOS_RELEASE_CHROME_MILESTONE) -le "120" ] && which device_management_client >/dev/null 2>&1; then
+                if [ $(lsbval CHROMEOS_RELEASE_CHROME_MILESTONE) -ge "120" ] && which device_management_client >/dev/null 2>&1; then
                     while true; do
                         device_management_client --action=remove_firmware_management_parameters >/dev/null 2>&1
                     done


### PR DESCRIPTION
ONLY v120 and above has `device_management_client` binary so #129 will only use `cryptohome` to remove FWMP on ALL VERSIONS.
The `device_management_client` binary does NOT exist on below v120.

I've already added a check if `device_management_client` exists in #124, so actually the version check or #129 is not needed.

FWMP has been moved from `cryptohome` to `device_management` on this commit: https://chromium-review.googlesource.com/c/chromiumos/platform2/+/4554116
