### PR TITLE
Add a null flag for "CloudExtensionRequestEnabled" in pollen.json (closes #88)

### DIFF
--- a/pollen.json
+++ b/pollen.json
@@ -42,6 +42,7 @@
   "ExtensionInstallAllowlist": null,
   "ExtensionInstallBlocklist": null,
   "ExtensionSettings": null,
+  "CloudExtensionRequestEnabled": null,
   "PinnedLauncherApps": null,
   "BookmarkBarEnabled": null,
   "LidCloseAction": null,


### PR DESCRIPTION
erm yea it fixes https://github.com/rainestorme/murkmod/issues/88